### PR TITLE
fix/RC-1966 Traz informação completa do global identity

### DIFF
--- a/management/manager.go
+++ b/management/manager.go
@@ -8,7 +8,7 @@ import (
 
 type GlobalIdentityManager interface {
 	UserRoles(email string) ([]core.Role, error)
-	ListUsers(pageNumber, pageSize int, includeRoles bool) ([]core.User, error)
+	ListUsers(pageNumber, pageSize int, includeRoles bool) (*core.ListUsersResponse, error)
 }
 
 type globalIdentityManager struct {
@@ -59,7 +59,7 @@ func (gim *globalIdentityManager) UserRoles(email string) ([]core.Role, error) {
 	return roles, nil
 }
 
-func (gim *globalIdentityManager) ListUsers(pageNumber, pageSize int, includeRoles bool) ([]core.User, error) {
+func (gim *globalIdentityManager) ListUsers(pageNumber, pageSize int, includeRoles bool) (*core.ListUsersResponse, error) {
 
 	url := fmt.Sprintf(gim.globalIdentityHost+listUsers, gim.applicationKey, pageNumber, pageSize, includeRoles)
 
@@ -69,7 +69,7 @@ func (gim *globalIdentityManager) ListUsers(pageNumber, pageSize int, includeRol
 		return nil, err
 	}
 
-	response := new(listUsersResponse)
+	response := new(core.ListUsersResponse)
 	if err = resp.JSON(&response); err != nil {
 		return nil, err
 	}
@@ -77,21 +77,7 @@ func (gim *globalIdentityManager) ListUsers(pageNumber, pageSize int, includeRol
 		return nil, err
 	}
 
-	users := make([]core.User, len(response.Users))
-
-	for i, user := range response.Users {
-		users[i] = core.User{
-			Name:      user.Name,
-			Active:    user.Active,
-			Roles:     user.Roles,
-			Email:     user.Email,
-			Comment:   user.Comment,
-			LockedOut: user.LockedOut,
-			UserKey:   user.UserKey,
-		}
-	}
-
-	return users, nil
+	return response, nil
 }
 
 func (gim *globalIdentityManager) requestOptions() *core.RequestOptions {

--- a/management/manager_test.go
+++ b/management/manager_test.go
@@ -105,7 +105,7 @@ func (suite *ManagementSuite) TestListUsersOk() {
 
 	users, err := suite.manager.ListUsers(1, 1, true)
 
-	assert.True(suite.T(), len(users) > 0)
+	assert.True(suite.T(), len(users.Users) > 0)
 	assert.Nil(suite.T(), err)
 }
 

--- a/management/response.go
+++ b/management/response.go
@@ -12,12 +12,3 @@ type role struct {
 	Description string `json:"description"`
 	Active      bool   `json:"active"`
 }
-
-type listUsersResponse struct {
-	Users     []core.User `json:"users"`
-	FirstPage int `json:"FirstPage"`
-	NextPage  int `json:"NextPage"`
-	LastPage  int `json:"LastPage"`
-	TotalRows int `json:"TotalRows"`
-	*core.Response
-}

--- a/models.go
+++ b/models.go
@@ -18,7 +18,7 @@ type User struct {
 	Comment   string `json:"comment"`
 	Active    bool `json:"active"`
 	LockedOut bool `json:"lockedOut"`
-	Roles     []string `json:"roles"`
+	Roles     []string `json:"roles,omitempty"`
 }
 
 type ListUsersResponse struct {

--- a/models.go
+++ b/models.go
@@ -20,3 +20,12 @@ type User struct {
 	LockedOut bool `json:"lockedOut"`
 	Roles     []string `json:"roles"`
 }
+
+type ListUsersResponse struct {
+	Users     []User `json:"users"`
+	FirstPage int `json:"FirstPage"`
+	NextPage  int `json:"NextPage"`
+	LastPage  int `json:"LastPage"`
+	TotalRows int `json:"TotalRows"`
+	*Response
+}

--- a/response.go
+++ b/response.go
@@ -3,7 +3,7 @@ package globalidentity
 // Response is the base response of Global Identity.
 type Response struct {
 	Success         bool     `json:"Success"`
-	OperationReport []string `json:"OperationReport"`
+	OperationReport []string `json:"OperationReport,omitempty"`
 }
 
 // Validate checks success of response.


### PR DESCRIPTION
**O que?**
Corrige retorno da função que lista usuários da aplicação.

**Por que?**
Não trazíamos toda a informação do global-identity, como quantidade de páginas e etc.

**Como?**
Mapeia todos os campos para a estrutura do response e a torna pública para facilitar seu uso "do lado de fora".